### PR TITLE
Return guid and keyName for ref/multRef attribute when ci type header is queried

### DIFF
--- a/cmdb-core/src/main/java/com/webank/cmdb/dto/CiTypeHeaderDto.java
+++ b/cmdb-core/src/main/java/com/webank/cmdb/dto/CiTypeHeaderDto.java
@@ -26,6 +26,10 @@ public class CiTypeHeaderDto extends CiTypeAttrDto {
     public void addStringValues(List<String> valList) {
         vals.addAll(valList);
     }
+    
+    public void addValues(List<?> valList) {
+    	vals.addAll(valList);
+    }
 
     class EnumValue {
         private int id;
@@ -55,6 +59,30 @@ public class CiTypeHeaderDto extends CiTypeAttrDto {
             this.code = code;
         }
 
+    }
+    
+    static public class CiKeyPair{
+    	private String guid;
+    	private String keyName;
+    	
+    	public CiKeyPair(String guid,String keyName) {
+    		this.guid = guid;
+    		this.keyName = keyName;
+    	}
+    	
+		public String getGuid() {
+			return guid;
+		}
+		public void setGuid(String guid) {
+			this.guid = guid;
+		}
+		public String getKeyName() {
+			return keyName;
+		}
+		public void setKeyName(String keyName) {
+			this.keyName = keyName;
+		}
+    	
     }
 
     public List<Object> getVals() {

--- a/cmdb-core/src/main/java/com/webank/cmdb/service/CiService.java
+++ b/cmdb-core/src/main/java/com/webank/cmdb/service/CiService.java
@@ -10,6 +10,7 @@ import com.webank.cmdb.dto.AdhocIntegrationQueryDto;
 import com.webank.cmdb.dto.CiData;
 import com.webank.cmdb.dto.CiDataTreeDto;
 import com.webank.cmdb.dto.CiIndentity;
+import com.webank.cmdb.dto.CiTypeHeaderDto.CiKeyPair;
 import com.webank.cmdb.dto.Filter;
 import com.webank.cmdb.dto.IntQueryResponseHeader;
 import com.webank.cmdb.dto.QueryRequest;
@@ -81,5 +82,5 @@ public interface CiService extends CmdbService {
 
     Object getCiBeanObject(EntityManager entityManager, int ciTypeId, String guid);
     
-    List<String> retrieveGuids(int ciTypeId);
+    List<CiKeyPair> retrieveKeyPairs(int ciTypeId);
 }

--- a/cmdb-core/src/main/java/com/webank/cmdb/service/impl/CiTypeServiceImpl.java
+++ b/cmdb-core/src/main/java/com/webank/cmdb/service/impl/CiTypeServiceImpl.java
@@ -43,6 +43,7 @@ import com.webank.cmdb.dto.CiTypeAttrGroupDto;
 import com.webank.cmdb.dto.CiTypeCategoryDto;
 import com.webank.cmdb.dto.CiTypeDto;
 import com.webank.cmdb.dto.CiTypeHeaderDto;
+import com.webank.cmdb.dto.CiTypeHeaderDto.CiKeyPair;
 import com.webank.cmdb.dto.CiTypeReferenceDto;
 import com.webank.cmdb.dto.QueryRequest;
 import com.webank.cmdb.dto.QueryResponse;
@@ -426,9 +427,9 @@ public class CiTypeServiceImpl implements CiTypeService {
                     });
                 }
             }else if ((InputType.Reference.equals(inputType) || InputType.MultRef.equals(inputType)) && attr.getReferenceId() != null) {
-                List<String> guids = ciService.retrieveGuids(attr.getReferenceId());
-                if (guids != null && guids.size() > 0) {
-                    headerDto.addStringValues(guids);
+                List<CiKeyPair> ciKeyPairs = ciService.retrieveKeyPairs(attr.getReferenceId());
+                if (ciKeyPairs != null && ciKeyPairs.size() > 0) {
+                    headerDto.addValues(ciKeyPairs);
                 }                
             }
             headerDtos.add(headerDto);

--- a/cmdb-core/src/test/java/com/webank/cmdb/controller/CiTypeControllerTest.java
+++ b/cmdb-core/src/test/java/com/webank/cmdb/controller/CiTypeControllerTest.java
@@ -414,4 +414,14 @@ public class CiTypeControllerTest extends LegacyAbstractBaseControllerTest {
                 .andExpect(jsonPath("$.data.length()", is(0)));
 
     }
+    
+    @Test
+    public void getCiTypeHeaderThenReturnHeaderValueProperly() throws Exception {
+        mvc.perform(get("/ciType/3/header"))
+        .andExpect(jsonPath("$.statusCode", is("OK")))
+        .andExpect(jsonPath("$.data", hasSize(14)))
+        .andExpect(jsonPath("$.data[10].vals", hasSize(2)))//system id
+        .andExpect(jsonPath("$.data[10].vals[0].guid", is("0002_0000000002")))
+        .andExpect(jsonPath("$.data[10].vals[0].keyName", is("public system")));
+    }
 }


### PR DESCRIPTION
When CI Type header is query, the vals of ref/multRef attribute will be returned as below (guid and keyName pair)

```
			"vals": [
				{
					"guid": "0002_0000000002",
					"keyName": "public system"
				},
				{
					"guid": "0002_0000000001",
					"keyName": "Bank system"
				}
			]
```