### PR TITLE
#551 Build WeCMDB base on profiles

### DIFF
--- a/cmdb-core/pom.xml
+++ b/cmdb-core/pom.xml
@@ -153,6 +153,32 @@
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>build</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>plugin</id>
+			<activation>
+				<property>
+					<name>buildType</name>
+					<value>plugin</value>
+				</property>
+			</activation>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/cmdb-plugin/pom.xml
+++ b/cmdb-plugin/pom.xml
@@ -54,6 +54,10 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,30 @@
 		</plugins>
 	</build>
 
-	<modules>
-		<module>cmdb-ui</module>
-		<module>cmdb-core</module>
-		<module>cmdb-plugin</module>
-	</modules>
+	<profiles>
+		<profile>
+			<id>build</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<modules>
+				<module>cmdb-ui</module>
+				<module>cmdb-core</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>plugin</id>
+			<activation>
+				<property>
+					<name>buildType</name>
+					<value>plugin</value>
+				</property>
+			</activation>
+			<modules>
+				<module>cmdb-ui</module>
+				<module>cmdb-core</module>
+				<module>cmdb-plugin</module>
+			</modules>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Hi Reviewers:

The PR here is to address the issue of building WeCMDB in standalone mode - the output jar is executable.

Two modes are working well now after tested:
**Standalone mode:**
 mvn -U clean install -Dmaven.test.skip=true

**Plugin mode (for WeCube):**
mvn -U clean install -Dmaven.test.skip=true -DbuildType=plugin

Regards,
Jordan.