### PR TITLE
:bug: #680 permission management select do not need to filter

### DIFF
--- a/cmdb-ui/src/pages/admin/permission-management.vue
+++ b/cmdb-ui/src/pages/admin/permission-management.vue
@@ -376,7 +376,8 @@ export default {
               ciType: { id: h.referenceId, name: h.name },
               type: 'text',
               ...components[h.inputType],
-              isMultiple: h.inputType === 'select'
+              isMultiple: h.inputType === 'select',
+              notFilte: true
             }
           })
           .concat(this.defaultColumns)

--- a/cmdb-ui/src/pages/admin/permission-management.vue
+++ b/cmdb-ui/src/pages/admin/permission-management.vue
@@ -377,7 +377,7 @@ export default {
               type: 'text',
               ...components[h.inputType],
               isMultiple: h.inputType === 'select',
-              notFilte: true
+              filterRule: null
             }
           })
           .concat(this.defaultColumns)

--- a/cmdb-ui/src/pages/components/table.js
+++ b/cmdb-ui/src/pages/components/table.js
@@ -600,13 +600,12 @@ export default {
                         ? params.row[col.inputKey]
                         : ''
                       : params.row[col.inputKey],
-                  filterParams:
-                      params.column.filterRule && !params.column.notFilte
-                        ? {
-                          attrId: params.column.ciTypeAttrId,
-                          params: params.row
-                        }
-                        : null,
+                  filterParams: params.column.filterRule
+                    ? {
+                      attrId: params.column.ciTypeAttrId,
+                      params: params.row
+                    }
+                    : null,
                   isMultiple: params.column.isMultiple,
                   options: params.column.optionKey
                     ? _this.ascOptions[params.row[col.optionKey]]

--- a/cmdb-ui/src/pages/components/table.js
+++ b/cmdb-ui/src/pages/components/table.js
@@ -600,12 +600,13 @@ export default {
                         ? params.row[col.inputKey]
                         : ''
                       : params.row[col.inputKey],
-                  filterParams: params.column.filterRule
-                    ? {
-                      attrId: params.column.ciTypeAttrId,
-                      params: params.row
-                    }
-                    : null,
+                  filterParams:
+                      params.column.filterRule && !params.column.notFilte
+                        ? {
+                          attrId: params.column.ciTypeAttrId,
+                          params: params.row
+                        }
+                        : null,
                   isMultiple: params.column.isMultiple,
                   options: params.column.optionKey
                     ? _this.ascOptions[params.row[col.optionKey]]


### PR DESCRIPTION
权限管理页面，数据详情弹框里的枚举类型下拉框不需要使用过滤规则进行过滤，应该展示全量数据